### PR TITLE
1. 处理编译警告：

### DIFF
--- a/longan/build.gradle
+++ b/longan/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "29.0.3"
+    buildToolsVersion "30.0.2"
 
     defaultConfig {
         minSdkVersion 21


### PR DESCRIPTION
The specified Android SDK Build Tools version (29.0.3) is ignored, as it is below the minimum supported version (30.0.2) for Android Gradle Plugin 4.2.1.

更新 buildToolsVersion 为 30.0.2 。